### PR TITLE
Added stack trace to the panic recovery

### DIFF
--- a/pkg/client/common/v1/websocket.go
+++ b/pkg/client/common/v1/websocket.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"strings"
 	"time"
+	"runtime/debug"
 
 	"github.com/dvonthenen/websocket"
 	klog "k8s.io/klog/v2"
@@ -265,6 +266,8 @@ func (c *WSClient) listen() {
 	defer func() {
 		if r := recover(); r != nil {
 			klog.V(1).Infof("Panic triggered\n")
+			klog.V(1).Infof("Panic: %v\n", r)
+			klog.V(1).Infof("Stack trace: %s\n", string(debug.Stack()))
 
 			// send error on callback
 			err := ErrFatalPanicRecovered

--- a/pkg/client/listen/v1/websocket/client_callback.go
+++ b/pkg/client/listen/v1/websocket/client_callback.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io"
 	"regexp"
+	"runtime/debug"
 	"strings"
 	"time"
 
@@ -246,6 +247,8 @@ func (c *WSCallback) ping() {
 	defer func() {
 		if r := recover(); r != nil {
 			klog.V(1).Infof("Panic triggered\n")
+			klog.V(1).Infof("Panic: %v\n", r)
+			klog.V(1).Infof("Stack trace: %s\n", string(debug.Stack()))
 
 			// send error on callback
 			err := common.ErrFatalPanicRecovered
@@ -289,6 +292,8 @@ func (c *WSCallback) flush() {
 	defer func() {
 		if r := recover(); r != nil {
 			klog.V(1).Infof("Panic triggered\n")
+			klog.V(1).Infof("Panic: %v\n", r)
+			klog.V(1).Infof("Stack trace: %s\n", string(debug.Stack()))
 
 			// send error on callback
 			err := common.ErrFatalPanicRecovered

--- a/pkg/client/listen/v1/websocket/client_channel.go
+++ b/pkg/client/listen/v1/websocket/client_channel.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io"
 	"regexp"
+	"runtime/debug"
 	"strings"
 	"time"
 
@@ -246,6 +247,8 @@ func (c *WSChannel) ping() {
 	defer func() {
 		if r := recover(); r != nil {
 			klog.V(1).Infof("Panic triggered\n")
+			klog.V(1).Infof("Panic: %v\n", r)
+			klog.V(1).Infof("Stack trace: %s\n", string(debug.Stack()))
 
 			// send error on callback
 			err := common.ErrFatalPanicRecovered
@@ -289,6 +292,8 @@ func (c *WSChannel) flush() {
 	defer func() {
 		if r := recover(); r != nil {
 			klog.V(1).Infof("Panic triggered\n")
+			klog.V(1).Infof("Panic: %v\n", r)
+			klog.V(1).Infof("Stack trace: %s\n", string(debug.Stack()))
 
 			// send error on callback
 			err := common.ErrFatalPanicRecovered

--- a/pkg/client/speak/v1/websocket/client_callback.go
+++ b/pkg/client/speak/v1/websocket/client_callback.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"regexp"
+	"runtime/debug"
 	"strings"
 	"time"
 
@@ -213,6 +214,8 @@ func (c *WSCallback) flush() {
 	defer func() {
 		if r := recover(); r != nil {
 			klog.V(1).Infof("Panic triggered\n")
+			klog.V(1).Infof("Panic: %v\n", r)
+			klog.V(1).Infof("Stack trace: %s\n", string(debug.Stack()))
 
 			// send error on callback
 			err := common.ErrFatalPanicRecovered

--- a/pkg/client/speak/v1/websocket/client_channel.go
+++ b/pkg/client/speak/v1/websocket/client_channel.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"regexp"
+	"runtime/debug"
 	"strings"
 	"time"
 
@@ -212,6 +213,8 @@ func (c *WSChannel) flush() {
 	defer func() {
 		if r := recover(); r != nil {
 			klog.V(1).Infof("Panic triggered\n")
+			klog.V(1).Infof("Panic: %v\n", r)
+			klog.V(1).Infof("Stack trace: %s\n", string(debug.Stack()))
 
 			// send error on callback
 			err := common.ErrFatalPanicRecovered


### PR DESCRIPTION
## Proposed changes

Currently, when a panic occurs in the SDK, the error messages are generic and don't provide enough context for debugging:

"Panic triggered"
"ProcessError(fatal panic - attempt to recover) failed"
"listen: Fatal socket error"
<img width="909" alt="Screenshot 2025-01-06 at 23 51 51" src="https://github.com/user-attachments/assets/37003e4d-f525-41cc-a05d-f789f35a2bc0" />

This PR adds detailed stack traces to panic recovery scenarios to help developers better understand and troubleshoot the root cause of failures. The enhanced logging will show the full call stack where the panic originated, making it easier to identify issues.


## Types of changes

What types of changes does your code introduce to the community Go SDK?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update or tests (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I have lint'ed all of my code using repo standards
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->

